### PR TITLE
trigger 'tap' for non-touch-capable devices

### DIFF
--- a/src/toe.js
+++ b/src/toe.js
@@ -96,5 +96,14 @@ function registerSpecialEvent(eventName) {
 			setup: eventSetup,
 			teardown: eventTeardown
 		};
+	} else {
+		$.event.special.tap = {
+	            setup: function(data, namespaces) {
+	                $("body").on('click', function(e) { $(e.target).trigger('tap'); });
+	            },
+	            teardown: function(namespace) {
+	                $("body").off('click');
+	            }
+	        }
 	}
 }

--- a/src/toe.js
+++ b/src/toe.js
@@ -98,12 +98,18 @@ function registerSpecialEvent(eventName) {
 		};
 	} else {
 		$.event.special.tap = {
-	            setup: function(data, namespaces) {
-	                $("body").on('click', function(e) { $(e.target).trigger('tap'); });
-	            },
-	            teardown: function(namespace) {
-	                $("body").off('click');
-	            }
+			setup: function(data, namespaces) {
+				$(this).on('click', $.event.special.tap.handler );
+			},
+			teardown: function(namespace) {
+				$(this).off('click', $.event.special.tap.handler);
+			},
+			handler: function(e) { 
+				// set correct event type
+				e.type = "tap";
+				// trigger tap handlers
+				$.event.handle.apply( this, arguments ); 
+			}
 	        }
 	}
 }


### PR DESCRIPTION
Hi, 

I aliased 'click' with 'tap' when using mouse pointer(for non-touch-capable devices). It involves 5 lines of code and only affects non-touch capable devices.

Thanks for this great lib!
